### PR TITLE
Fixes the issue with . in url (closes #13)

### DIFF
--- a/src/ExportCrawlObserver.php
+++ b/src/ExportCrawlObserver.php
@@ -33,7 +33,7 @@ class ExportCrawlObserver extends CrawlObserver
 
     public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null)
     {
-        $isFile = isset(explode('.', $url->getPath())[1]);
+        $isFile = ! preg_match('/^((.+\.[\d]+[^\w]*)|((?:(?!\.).)*|))$/', $url->getPath());
 
         $targetPath = $isFile
             ? '/'.ltrim($url->getPath(), '/')


### PR DESCRIPTION
This regular expression will return `true` only if the tested url is something like (`foo.rss`, `foo.mp3` etc.), but not like (`v1.1.1`, `1.1` etc.)