### PR TITLE
feat: export sitemaps WIP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "nyholm/psr7": "^1.1",
         "psr/http-message": "^1.0",
         "spatie/crawler": "^4.3",
+        "spatie/laravel-sitemap": "^5.4",
         "symfony/http-foundation": "^4.2",
         "symfony/process": "^4.2",
         "symfony/psr-http-message-bridge": "^1.2"

--- a/config/export.php
+++ b/config/export.php
@@ -19,6 +19,16 @@ return [
     ],
 
     /*
+     * The exporter can optionally build a sitemap. You'll need to specify
+     * the URL (protocol & domain) to be used.
+     */
+    'sitemap' => [
+        'enabled' => env('EXPORT_SITEMAP_ENABLED', false),
+        'domain' => env('EXPORT_SITEMAP_DOMAIN', 'http://localhost'),
+        'filename' => env('EXPORT_SITEMAP_FILENAME', 'sitemap.xml'),
+    ],
+
+    /*
      * Files that should be included in the build.
      */
     'include' => [

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -34,6 +34,14 @@ class Exporter
         $this->crawler = (new Crawler(new InternalClient()));
     }
 
+    /**
+     * @return Filesystem
+     */
+    public function getFilesystem(): Filesystem
+    {
+        return $this->filesystem;
+    }
+
     public function entries(array $entries): Exporter
     {
         $this->entries = array_map(function (string $entry) {


### PR DESCRIPTION
This is a very early go at getting sitemaps generated along with the other files :)

I thought about doing it from scratch, but since there's already a spatie package (💯) I thought i'd try use that. It doesn't support setting a custom client (ie. our custom `InternalCrawler`), so i've jerry rigged it using reflection for the moment. If you are open, i'll PR against that repo to allow client config.

Once the sitemaps are generated, it copies them to the correct disk. I think this could also be PR'd to the sitemap to allow us to pass a disk to write to (currently it uses `file_put_contents)`