### PR TITLE
Update phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>


### PR DESCRIPTION
> Warning - The configuration file did not pass validation!
> Element 'log', attribute 'type': 'tap' is not a valid value of the local atomic type.