### PR TITLE
Check if dist folder exists.

### DIFF
--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -13,11 +13,15 @@ class ExportTest extends BaseTestCase
     protected const ABOUT_CONTENT = 'About';
     protected const FEED_CONTENT = 'Feed';
 
+    protected $distDirectory = __DIR__.'/dist';
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        exec('rm -r '.__DIR__.'/dist');
+        if (file_exists($this->distDirectory)) {
+            exec('rm -r '.$this->distDirectory);
+        }
 
         Route::get('/', function () {
             return static::HOME_CONTENT;


### PR DESCRIPTION
Initially there is no `dist` folder which results in a warning:

> rm: cannot remove '/build/spatie/laravel-export/tests/Feature/dist': No such file or directory
