### PR TITLE
Added version "^7.0" for `guzzlehttp/guzzle`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "illuminate/console": "^6.0 || ^7.0 || ^8.0",
         "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
         "illuminate/http": "^6.0 || ^7.0 || ^8.0",

--- a/src/Crawler/LocalClient.php
+++ b/src/Crawler/LocalClient.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use GuzzleHttp\Promise\PromiseInterface;
 
 class LocalClient extends Client
 {
@@ -29,7 +30,7 @@ class LocalClient extends Client
         $this->psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
     }
 
-    public function sendAsync(RequestInterface $request, array $options = [])
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
     {
         $response = $this->kernel->handle(
             Request::create((string) $request->getUri())

--- a/src/Crawler/LocalClient.php
+++ b/src/Crawler/LocalClient.php
@@ -4,12 +4,12 @@ namespace Spatie\Export\Crawler;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Http\Request;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use GuzzleHttp\Promise\PromiseInterface;
 
 class LocalClient extends Client
 {


### PR DESCRIPTION
Laravel 8 support (fixes #63)