### PR TITLE
Add $foundOnUrl to output message on exception

### DIFF
--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -29,6 +29,10 @@ class Observer extends CrawlObserver
     public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null)
     {
         if ($response->getStatusCode() !== 200) {
+            if (!empty($foundOnUrl)) {
+                throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
+            }
+            
             throw new RuntimeException("URL [{$url}] returned status code [{$response->getStatusCode()}]");
         }
       


### PR DESCRIPTION
If an exception occurs and $foundOnUrl is set the message shows the URL where the link was found. That way it is easier to detect the origin of the failure.