### PR TITLE
upgrade spatie/crawler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^6.0|^7.0|^8.0",
         "nyholm/psr7": "^1.1",
         "psr/http-message": "^1.0",
-        "spatie/crawler": "^4.7",
+        "spatie/crawler": "^7.0",
         "symfony/console": "^4.2|^5.0",
         "symfony/dom-crawler": "^5.2",
         "symfony/http-foundation": "^4.2|^5.0",

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
-use Spatie\Crawler\CrawlObserver;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Spatie\Export\Destination;
 use Spatie\Export\Traits\NormalizedPath;
 
@@ -26,23 +26,23 @@ class Observer extends CrawlObserver
         $this->destination = $destination;
     }
 
-    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null)
+    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null): void
     {
         if ($response->getStatusCode() !== 200) {
             if (! empty($foundOnUrl)) {
                 throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
             }
-            
+
             throw new RuntimeException("URL [{$url}] returned status code [{$response->getStatusCode()}]");
         }
-      
+
         $this->destination->write(
             $this->normalizePath($url->getPath()),
             (string) $response->getBody()
         );
     }
 
-    public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null)
+    public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null): void
     {
         throw $requestException;
     }

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -4,7 +4,7 @@ namespace Spatie\Export\Jobs;
 
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlInternalUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
 use Spatie\Export\Crawler\LocalClient;
 use Spatie\Export\Crawler\Observer;
 use Spatie\Export\Destination;


### PR DESCRIPTION
Following https://github.com/spatie/crawler/pull/371 I think we are able to upgrade `spatie/crawler`. The ideia was make work on v5.0 (to solve https://github.com/spatie/laravel-export/discussions/69), but the latest tag seems work nicely.