### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: spatie
+custom: https://spatie.be/open-source/support-us

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: dependabot-auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          
+      - name: Auto-merge Dependabot PRs for semver-minor updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          
+      - name: Auto-merge Dependabot PRs for semver-patch updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,12 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3]
-                laravel: [7.*, 8.*]
+                php: [8.1, 8.0, 7.4]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: 7.*
-                        testbench: 5.*
                     -   laravel: 8.*
-                        testbench: 6.*
+                        testbench: ^6.23
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -44,7 +42,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: run-tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.1, 8.0]
-                laravel: [8.*]
+                laravel: [^8.73]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: ^8.73

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
                 laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: 8.*
+                    -   laravel: ^8.73
                         testbench: ^6.23
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4]
+                php: [8.1, 8.0]
                 laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -34,10 +34,6 @@ jobs:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                     coverage: none
-
-            -   name: Setup specific Guzzle version
-                run: composer require guzzlehttp/guzzle ^7.0
-                if: ${{ matrix.dependency-version ==  'prefer-lowest' && matrix.php == '8.0'}}
 
             -   name: Install dependencies
                 run: |

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -16,24 +16,24 @@
         }
     ],
     "require": {
-        "php": "^7.3|^7.4|^8.0",
-        "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "nyholm/psr7": "^1.1",
+        "php": "^7.4|^8.0",
+        "guzzlehttp/guzzle": "^7.4",
+        "illuminate/console": "^8.73",
+        "illuminate/contracts": "^8.73",
+        "illuminate/http": "^8.73",
+        "illuminate/support": "^8.73",
+        "nyholm/psr7": "^1.4",
         "psr/http-message": "^1.0",
-        "spatie/crawler": "^4.7",
-        "symfony/console": "^4.2|^5.0",
-        "symfony/dom-crawler": "^5.2",
-        "symfony/http-foundation": "^4.2|^5.0",
-        "symfony/process": "^5.0",
-        "symfony/psr-http-message-bridge": "^2.0"
+        "spatie/crawler": "^7.0",
+        "symfony/console": "^5.3",
+        "symfony/dom-crawler": "^5.3",
+        "symfony/http-foundation": "^5.3",
+        "symfony/process": "^5.3",
+        "symfony/psr-http-message-bridge": "^2.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^9.0"
+        "orchestra/testbench": "^6.23",
+        "phpunit/phpunit": "^9.5"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "guzzlehttp/guzzle": "^7.4",
         "illuminate/console": "^8.73",
         "illuminate/contracts": "^8.73",
@@ -24,7 +24,7 @@
         "illuminate/support": "^8.73",
         "nyholm/psr7": "^1.4",
         "psr/http-message": "^1.0",
-        "spatie/crawler": "^6.0|^7.0",
+        "spatie/crawler": "^7.0",
         "symfony/console": "^5.3",
         "symfony/dom-crawler": "^5.3",
         "symfony/http-foundation": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^8.73",
         "nyholm/psr7": "^1.4",
         "psr/http-message": "^1.0",
-        "spatie/crawler": "^7.0",
+        "spatie/crawler": "^6.0|^7.0",
         "symfony/console": "^5.3",
         "symfony/dom-crawler": "^5.3",
         "symfony/http-foundation": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^8.73",
         "nyholm/psr7": "^1.4",
         "psr/http-message": "^1.0",
-        "spatie/crawler": "^7.0",
+        "spatie/crawler": "^7.0.5",
         "symfony/console": "^5.3",
         "symfony/dom-crawler": "^5.3",
         "symfony/http-foundation": "^5.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,10 +19,20 @@
     verbose="true"
 >
     <testsuites>
-        <testsuite name="VendorName Test Suite">
+        <testsuite name="Spatie Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
-use Spatie\Crawler\CrawlObserver;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Spatie\Export\Destination;
 use Spatie\Export\Traits\NormalizedPath;
 
@@ -25,8 +25,8 @@ class Observer extends CrawlObserver
         $this->entry = $entry;
         $this->destination = $destination;
     }
-
-    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null)
+    
+    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null): void
     {
         if ($response->getStatusCode() !== 200) {
             if (! empty($foundOnUrl)) {
@@ -42,7 +42,7 @@ class Observer extends CrawlObserver
         );
     }
 
-    public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null)
+    public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null): void
     {
         throw $requestException;
     }

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -4,7 +4,7 @@ namespace Spatie\Export\Jobs;
 
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlInternalUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
 use Spatie\Export\Crawler\LocalClient;
 use Spatie\Export\Crawler\Observer;
 use Spatie\Export\Destination;


### PR DESCRIPTION
This PR adds PHP 8.1 support to the tests workflow.  Additionally, it:

- **drops PHP 7.x support**
- **drops Laravel 6.x, 7.x support**
- bumps versions in `composer.json` to their latest where possible
- updates `PHPUnit` config to add coverage generation to match other packages
- adds update changelog workflow
- adds `dependabot` workflow & config
- updates the namespaces of Crawler classes in several source files to work with `spatie/crawler` v7

_This repository needs its primary branch renamed from `master` to `main`._