### PR TITLE
Add X-Laravel-Export header

### DIFF
--- a/src/Crawler/LocalClient.php
+++ b/src/Crawler/LocalClient.php
@@ -32,9 +32,11 @@ class LocalClient extends Client
 
     public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
     {
-        $response = $this->kernel->handle(
-            Request::create((string) $request->getUri())
-        );
+        $localRequest = Request::create((string) $request->getUri());
+
+        $localRequest->headers->set('X-Laravel-Export', 'true');
+
+        $response = $this->kernel->handle($localRequest);
 
         $psrResponse = $this->psrHttpFactory->createResponse($response);
 


### PR DESCRIPTION
There is currently no way to differentiate laravel export crawler request besides `User-Agent: Symfony` header. This PR adds a `X-Laravel-Export: true` header to request handled in LocalClient.