### PR TITLE
Fix directory detection for Windows directory symlinks

### DIFF
--- a/src/Jobs/IncludeFile.php
+++ b/src/Jobs/IncludeFile.php
@@ -55,7 +55,14 @@ class IncludeFile
         );
 
         foreach ($iterator as $item) {
-            if ($item->isDir()) {
+            // Checkin isDir() on $item could lead to false negatives due to the way
+            // symlinks are handled on Windows, especially if created under Git-For-Windows.
+            // When debugging it could lead to isDir(), isFile() and isLink() to all 3 be false.
+            // Despite that, getRealPath() does return the resolved symlink path.
+            // Hence why we check on $realItem instead.
+            // Copying Windows "symlinks" as files would also be "wrong" and not portable across file systems.
+            $realItem = new \SplFileInfo($item->getRealPath());
+            if ($realItem->isDir()) {
                 continue;
             }
 

--- a/src/Jobs/IncludeFile.php
+++ b/src/Jobs/IncludeFile.php
@@ -55,6 +55,10 @@ class IncludeFile
         );
 
         foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                continue;
+            }
+
             // Checkin isDir() on $item could lead to false negatives due to the way
             // symlinks are handled on Windows, especially if created under Git-For-Windows.
             // When debugging it could lead to isDir(), isFile() and isLink() to all 3 be false.
@@ -63,6 +67,15 @@ class IncludeFile
             // Copying Windows "symlinks" as files would also be "wrong" and not portable across file systems.
             $realItem = new \SplFileInfo($item->getRealPath());
             if ($realItem->isDir()) {
+                // Since it was a symlink, the subfiles weren't crawled recursively
+                // so we need to "recursively" export that directory in our export
+                // destination to maintain the expected file structure, and to copy
+                // absolutely all the files we needed to copy.
+                $this->exportIncludedDirectory(
+                    $realItem->getPathname(),
+                    $target.'/'.$iterator->getSubPathName(),
+                    $destination
+                );
                 continue;
             }
 


### PR DESCRIPTION
Apps running on Windows that had used `php storage:link` would see all their exports fail due to `public/storage` being treated as a file instead of a directory.

Stepping into a debugger revealed that `SplFileInfo::isDir()`, `SplFileInfo::isFile()` and `SplFileInfo::isLink()` all returned false on that specific entry.

However, `SplFileInfo::getRealPath()` does yield the correct directory path (i.e. the one the symlink points to).

As such, this PR simply makes directory detection portable on all OS that could suffer from this specific issue.