### PR TITLE
Add X-Laravel-Export header to request on export path

### DIFF
--- a/src/Jobs/ExportPath.php
+++ b/src/Jobs/ExportPath.php
@@ -23,9 +23,11 @@ class ExportPath
 
     public function handle(Kernel $kernel, Destination $destination, UrlGenerator $urlGenerator)
     {
-        $response = $kernel->handle(
-            Request::create($urlGenerator->to($this->path))
-        );
+        $localRequest = Request::create($urlGenerator->to($this->path));
+
+        $localRequest->headers->set('X-Laravel-Export', 'true');
+
+        $response = $kernel->handle($localRequest);
 
         if ($response->status() !== 200) {
             throw new RuntimeException("Path [{$this->path}] returned status code [{$response->status()}]");

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -31,6 +31,11 @@ function assertExportedFile(string $path, string $content): void
     assertEquals($content, file_get_contents($path));
 }
 
+function assertRequestsHasHeader(): void
+{
+    expect(Route::getCurrentRequest()->header('X-Laravel-Export'))->toEqual('true');
+}
+
 beforeEach(function () {
     $this->distDirectory = __DIR__.DIRECTORY_SEPARATOR.'dist';
 
@@ -57,6 +62,7 @@ afterEach(function () {
     assertHomeExists();
     assertAboutExists();
     assertFeedBlogAtomExists();
+    assertRequestsHasHeader();
 });
 
 it('crawls and exports routes', function () {


### PR DESCRIPTION
Following up on #110, I've added the `X-Laravel-Export` header to requests sent when exporting paths. I've added an assertion to test the header presence in local requests.