### PR TITLE
Allow redirects when crawling

### DIFF
--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -28,7 +28,8 @@ class Observer extends CrawlObserver
 
     public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
     {
-        if ($response->getStatusCode() !== 200) {
+        // Allow all success status codes and redirect codes
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() > 399) {
             if (! empty($foundOnUrl)) {
                 throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
             }


### PR DESCRIPTION
Before this patch, the exporter would fail on redirects. This change allows all 2xx and 3xx status codes so the crawler can follow redirects where needed.