### PR TITLE
Allow redirects export

### DIFF
--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -28,7 +28,7 @@ class Observer extends CrawlObserver
 
     public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
     {
-        if ($response->getStatusCode() !== 200) {
+        if (! $this->isSuccesfullOrRedirect($response->getStatusCode())) {
             if (! empty($foundOnUrl)) {
                 throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
             }
@@ -45,5 +45,10 @@ class Observer extends CrawlObserver
     public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
     {
         throw $requestException;
+    }
+
+    protected function isSuccesfullOrRedirect(int $statusCode): bool
+    {
+        return in_array($statusCode, [200,301,302]);
     }
 }

--- a/src/Jobs/ExportPath.php
+++ b/src/Jobs/ExportPath.php
@@ -29,10 +29,15 @@ class ExportPath
 
         $response = $kernel->handle($localRequest);
 
-        if ($response->status() !== 200) {
+        if (! $this->isSuccesfullOrRedirect($response->status())) {
             throw new RuntimeException("Path [{$this->path}] returned status code [{$response->status()}]");
         }
 
         $destination->write($this->normalizePath($this->path), $response->content());
+    }
+
+    protected function isSuccesfullOrRedirect(int $status): bool
+    {
+        return in_array($status, [200,301,302]);
     }
 }

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -6,9 +6,31 @@ use Spatie\Export\Exporter;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFileExists;
 
-const HOME_CONTENT = '<a href="feed/blog.atom" title="all blogposts">Feed</a>Home <a href="about">About</a>';
+const HOME_CONTENT = <<<'HTML'
+    <a href="feed/blog.atom" title="all blogposts">Feed</a>
+    Home
+    <a href="about">About</a>
+    <a href="redirect">Spatie</a>
+HTML;
+
 const ABOUT_CONTENT = 'About';
+
 const FEED_CONTENT = 'Feed';
+
+const REDIRECT_CONTENT = <<<'HTML'
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="refresh" content="0;url='https://spatie.be'" />
+
+        <title>Redirecting to https://spatie.be</title>
+    </head>
+    <body>
+        Redirecting to <a href="https://spatie.be">https://spatie.be</a>.
+    </body>
+</html>
+HTML;
 
 function assertHomeExists(): void
 {
@@ -23,6 +45,11 @@ function assertAboutExists(): void
 function assertFeedBlogAtomExists(): void
 {
     assertExportedFile(__DIR__.'/dist/feed/blog.atom', FEED_CONTENT);
+}
+
+function assertRedirectExists(): void
+{
+    assertExportedFile(__DIR__.'/dist/redirect/index.html', REDIRECT_CONTENT);
 }
 
 function assertExportedFile(string $path, string $content): void
@@ -56,12 +83,15 @@ beforeEach(function () {
     Route::get('feed/blog.atom', function () {
         return FEED_CONTENT;
     });
+
+    Route::redirect('redirect', 'https://spatie.be');
 });
 
 afterEach(function () {
     assertHomeExists();
     assertAboutExists();
     assertFeedBlogAtomExists();
+    assertRedirectExists();
     assertRequestsHasHeader();
 });
 
@@ -72,14 +102,14 @@ it('crawls and exports routes', function () {
 it('exports paths', function () {
     app(Exporter::class)
         ->crawl(false)
-        ->paths(['/', '/about', '/feed/blog.atom'])
+        ->paths(['/', '/about', '/feed/blog.atom', '/redirect'])
         ->export();
 });
 
 it('exports urls', function () {
     app(Exporter::class)
         ->crawl(false)
-        ->urls([url('/'), url('/about'), url('/feed/blog.atom')])
+        ->urls([url('/'), url('/about'), url('/feed/blog.atom'), url('/redirect')])
         ->export();
 });
 
@@ -87,7 +117,7 @@ it('exports mixed', function () {
     app(Exporter::class)
         ->crawl(false)
         ->paths('/')
-        ->urls(url('/about'), url('/feed/blog.atom'))
+        ->urls(url('/about'), url('/feed/blog.atom'), url('/redirect'))
         ->export();
 });
 

--- a/tests/dist/index.html
+++ b/tests/dist/index.html
@@ -1,1 +1,4 @@
-<a href="feed/blog.atom" title="all blogposts">Feed</a>Home <a href="about">About</a>
+    <a href="feed/blog.atom" title="all blogposts">Feed</a>
+    Home
+    <a href="about">About</a>
+    <a href="redirect">Spatie</a>

--- a/tests/dist/redirect/index.html
+++ b/tests/dist/redirect/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="refresh" content="0;url='https://spatie.be'" />
+
+        <title>Redirecting to https://spatie.be</title>
+    </head>
+    <body>
+        Redirecting to <a href="https://spatie.be">https://spatie.be</a>.
+    </body>
+</html>


### PR DESCRIPTION
Allows export of redirects when Crawling or Exporting Paths.

Based on original proposal of @WesleyE in #130, taking into account @freekmurze [comment](https://github.com/spatie/laravel-export/pull/130#discussion_r1977089875) and including tests.