### PR TITLE
Add sitemap generation feature and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Laravel Export will scan your app and create an HTML page from every URL it craw
 
 A few example use cases for this package:
 
-- Build your own blog or site in Laravel with all the tools you're used to using. Export a static version and just upload it anywhere for hosting, no need for managing a full-blown server anymore.
+-   Build your own blog or site in Laravel with all the tools you're used to using. Export a static version and just upload it anywhere for hosting, no need for managing a full-blown server anymore.
 
-- Use something like [Nova](https://nova.laravel.com/), [Wink](https://github.com/themsaid/wink), [Filament](https://filamentphp.com/), [Sharp](https://sharp.code16.fr/), or any other admin panel to manage your site locally or on a remote server, then publish it to a service like Netlify. This gives you all benefits of a static site (speed, simple hosting, scalability) while still having a dynamic backend of some sort.
+-   Use something like [Nova](https://nova.laravel.com/), [Wink](https://github.com/themsaid/wink), [Filament](https://filamentphp.com/), [Sharp](https://sharp.code16.fr/), or any other admin panel to manage your site locally or on a remote server, then publish it to a service like Netlify. This gives you all benefits of a static site (speed, simple hosting, scalability) while still having a dynamic backend of some sort.
 
 ## Support us
 
@@ -102,6 +102,20 @@ return [
     ],
 ];
 ```
+
+#### Sitemap Generation
+
+By default, Laravel Export can generate a sitemap.xml file during the export process. This helps search engines index your static site correctly.
+
+Enable or disable this behavior using the sitemap option in the config/export.php file:
+
+```php
+return [
+    'sitemap' => true, // Set to false if you do not want a sitemap generated.
+];
+```
+
+This will automatically create a sitemap.xml file and place it at the root of your exported site directory, containing all the crawled and manually included paths.
 
 #### Configuration through code
 
@@ -188,6 +202,16 @@ php artisan export --skip-after
 php artisan export --skip-all
 ```
 
+#### Sitemap
+
+You can also control this feature using the CLI when running the export command.
+
+```bash
+php artisan export --sitemap
+```
+
+This flag will override the config setting and force sitemap generation, even if the config says otherwise.
+
 ## Usage
 
 To build a bundle, run the `export` command:
@@ -198,7 +222,7 @@ php artisan export
 
 ## Testing
 
-``` bash
+```bash
 composer test
 ```
 
@@ -224,8 +248,8 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 ## Credits
 
-- [Sebastian De Deyne](https://github.com/sebastiandedeyne)
-- [All Contributors](../../contributors)
+-   [Sebastian De Deyne](https://github.com/sebastiandedeyne)
+-   [All Contributors](../../contributors)
 
 ## License
 

--- a/config/export.php
+++ b/config/export.php
@@ -69,4 +69,9 @@ return [
         // 'deploy' => '/usr/local/bin/netlify deploy --prod',
     ],
 
+    /*
+     * If true, the exporter will generate a sitemap.xml after export.
+     */
+    'sitemap' => true,
+
 ];

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -12,7 +12,7 @@ class ExportCommand extends Command
 {
     protected $name = 'export';
 
-    protected $description = 'Export the entire app to a static site22';
+    protected $description = 'Export the entire app to a static site';
 
     public function __construct()
     {

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -12,7 +12,7 @@ class ExportCommand extends Command
 {
     protected $name = 'export';
 
-    protected $description = 'Export the entire app to a static site';
+    protected $description = 'Export the entire app to a static site22';
 
     public function __construct()
     {
@@ -36,6 +36,8 @@ class ExportCommand extends Command
         $this->addOption('skip-all', null, InputOption::VALUE_NONE, 'Skip all hooks');
         $this->addOption('skip-before', null, InputOption::VALUE_NONE, 'Skip all before hooks');
         $this->addOption('skip-after', null, InputOption::VALUE_NONE, 'Skip all after hooks');
+        $this->addOption('sitemap', null, InputOption::VALUE_NONE, 'Generate a sitemap.xml after export');
+
     }
 
     public function handle(Exporter $exporter)
@@ -44,10 +46,15 @@ class ExportCommand extends Command
 
         $this->info('Exporting site...');
 
-        $exporter->export();
+        $sitemap = $this->option('sitemap');
+
+        if ($sitemap) {
+            $this->info('Generating sitemap...');
+        }
+        $exporter->export($sitemap);
 
         if (config('export.disk')) {
-            $this->info('Files were saved to disk `'.config('export.disk').'`');
+            $this->info('Files were saved to disk `' . config('export.disk') . '`');
         } else {
             $this->info('Files were saved to `dist`');
         }
@@ -66,7 +73,7 @@ class ExportCommand extends Command
                 return $this->input->getOption("skip-{$name}");
             });
 
-        if (! count($beforeHooks)) {
+        if (!count($beforeHooks)) {
             return;
         }
 
@@ -86,7 +93,7 @@ class ExportCommand extends Command
                 return $this->input->getOption("skip-{$name}");
             });
 
-        if (! count($afterHooks)) {
+        if (!count($afterHooks)) {
             return;
         }
 

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -8,7 +8,9 @@ use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Spatie\Export\Destination;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Spatie\Export\Traits\NormalizedPath;
+use Spatie\Export\SitemapGenerator;
 
 class Observer extends CrawlObserver
 {
@@ -20,16 +22,25 @@ class Observer extends CrawlObserver
     /** @var \Spatie\Export\Destination */
     protected $destination;
 
-    public function __construct(string $entry, Destination $destination)
+    /** @var bool */
+    protected $sitemap;
+
+    /** @var array */
+    protected $crawledUrls = [];
+
+    public function __construct(string $entry, Destination $destination, bool $sitemap)
     {
         $this->entry = $entry;
         $this->destination = $destination;
+        $this->sitemap = $sitemap;
     }
 
     public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
     {
-        if (! $this->isSuccesfullOrRedirect($response->getStatusCode())) {
-            if (! empty($foundOnUrl)) {
+        $this->crawledUrls[] = (string) $url->getPath();
+
+        if (!$this->isSuccesfullOrRedirect($response->getStatusCode())) {
+            if (!empty($foundOnUrl)) {
                 throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
             }
 
@@ -50,5 +61,13 @@ class Observer extends CrawlObserver
     protected function isSuccesfullOrRedirect(int $statusCode): bool
     {
         return in_array($statusCode, [200, 301, 302]);
+    }
+
+    public function finishedCrawling(): void
+    {
+        if ($this->sitemap) {
+            $siteGen = new SitemapGenerator($this->crawledUrls);
+            $siteGen->handle(app(UrlGenerator::class), app(Destination::class));
+        }
     }
 }

--- a/src/ExportServiceProvider.php
+++ b/src/ExportServiceProvider.php
@@ -12,7 +12,7 @@ class ExportServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/export.php', 'export');
+        $this->mergeConfigFrom(__DIR__ . '/../config/export.php', 'export');
 
         $this->app->singleton(Destination::class, function () {
             return new FilesystemDestination($this->getDisk());
@@ -25,7 +25,7 @@ class ExportServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/export.php' => config_path('export.php'),
+                __DIR__ . '/../config/export.php' => config_path('export.php'),
             ], 'config');
 
             $this->commands([
@@ -37,13 +37,14 @@ class ExportServiceProvider extends ServiceProvider
             ->cleanBeforeExport(config('export.clean_before_export', false))
             ->crawl(config('export.crawl', false))
             ->paths(config('export.paths', []))
+            ->sitemap(config('export.sitemap', true))
             ->includeFiles(config('export.include_files', []))
             ->excludeFilePatterns(config('export.exclude_file_patterns', []));
     }
 
     protected function getDisk(): Filesystem
     {
-        if (! config('export.disk')) {
+        if (!config('export.disk')) {
             config([
                 'filesystems.disks.laravel_export' => [
                     'driver' => 'local',

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -24,6 +24,9 @@ class Exporter
     /** @var bool */
     protected $crawl = false;
 
+    /** @var bool */
+    protected $sitemap = true;
+
     /** @var string[] */
     protected $paths = [];
 
@@ -42,6 +45,12 @@ class Exporter
     public function cleanBeforeExport(bool $cleanBeforeExport): self
     {
         $this->cleanBeforeExport = $cleanBeforeExport;
+
+        return $this;
+    }
+    public function sitemap(bool $sitemap): self
+    {
+        $this->sitemap = $sitemap;
 
         return $this;
     }
@@ -87,8 +96,9 @@ class Exporter
         return $this;
     }
 
-    public function export()
+    public function export(bool $sitemapOption = true): void
     {
+        $includeSitemap = $this->sitemap || $sitemapOption;
         if ($this->cleanBeforeExport) {
             $this->dispatcher->dispatchNow(
                 new CleanDestination
@@ -96,8 +106,16 @@ class Exporter
         }
 
         if ($this->crawl) {
+
             $this->dispatcher->dispatchNow(
-                new CrawlSite
+                new CrawlSite($includeSitemap)
+            );
+
+        }
+
+        if (($includeSitemap && $this->paths) && !$this->crawl) {
+            $this->dispatcher->dispatchNow(
+                new SitemapGenerator($this->paths)
             );
         }
 

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -11,12 +11,20 @@ use Spatie\Export\Destination;
 
 class CrawlSite
 {
+    /** @var bool */
+    protected $sitemap;
+
+    public function __construct(bool $sitemap)
+    {
+        $this->sitemap = $sitemap;
+    }
+
     public function handle(UrlGenerator $urlGenerator, Destination $destination): void
     {
         $entry = $urlGenerator->to('/');
 
-        (new Crawler(new LocalClient))
-            ->setCrawlObserver(new Observer($entry, $destination))
+        $crawler = (new Crawler(new LocalClient))
+            ->setCrawlObserver(new Observer($entry, $destination, $this->sitemap))
             ->setCrawlProfile(new CrawlInternalUrls($entry))
             ->startCrawling($entry);
     }

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Export;
+use Spatie\Export\Destination;
+use Illuminate\Contracts\Routing\UrlGenerator;
+
+class SitemapGenerator
+{
+
+    /** @var string[] */
+    protected $urls;
+
+    public function __construct($urls)
+    {
+        $this->urls = $urls;
+    }
+
+    public function handle(UrlGenerator $urlGenerator, Destination $destination): void
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . PHP_EOL;
+
+        foreach ($this->urls as $url) {
+            $fullUrl = $urlGenerator->to($url);
+            $xml .= '  <url>' . PHP_EOL;
+            $xml .= '    <loc>' . htmlspecialchars($fullUrl) . '</loc>' . PHP_EOL;
+            $xml .= '  </url>' . PHP_EOL;
+        }
+        $xml .= '</urlset>' . PHP_EOL;
+        $destination->write('/sitemap.xml', $xml);
+    }
+}

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -34,22 +34,22 @@ HTML;
 
 function assertHomeExists(): void
 {
-    assertExportedFile(__DIR__.'/dist/index.html', HOME_CONTENT);
+    assertExportedFile(__DIR__ . '/dist/index.html', HOME_CONTENT);
 }
 
 function assertAboutExists(): void
 {
-    assertExportedFile(__DIR__.'/dist/about/index.html', ABOUT_CONTENT);
+    assertExportedFile(__DIR__ . '/dist/about/index.html', ABOUT_CONTENT);
 }
 
 function assertFeedBlogAtomExists(): void
 {
-    assertExportedFile(__DIR__.'/dist/feed/blog.atom', FEED_CONTENT);
+    assertExportedFile(__DIR__ . '/dist/feed/blog.atom', FEED_CONTENT);
 }
 
 function assertRedirectExists(): void
 {
-    assertExportedFile(__DIR__.'/dist/redirect/index.html', REDIRECT_CONTENT);
+    assertExportedFile(__DIR__ . '/dist/redirect/index.html', REDIRECT_CONTENT);
 }
 
 function assertExportedFile(string $path, string $content): void
@@ -64,13 +64,14 @@ function assertRequestsHasHeader(): void
 }
 
 beforeEach(function () {
-    $this->distDirectory = __DIR__.DIRECTORY_SEPARATOR.'dist';
+    $this->distDirectory = __DIR__ . DIRECTORY_SEPARATOR . 'dist';
 
     if (file_exists($this->distDirectory)) {
         exec(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'
-            ? 'del '.$this->distDirectory.' /q'
-            : 'rm -r '.$this->distDirectory);
+            ? 'del ' . $this->distDirectory . ' /q'
+            : 'rm -r ' . $this->distDirectory);
     }
+
 
     Route::get('/', function () {
         return HOME_CONTENT;
@@ -97,6 +98,7 @@ afterEach(function () {
 
 it('crawls and exports routes', function () {
     app(Exporter::class)->export();
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
 });
 
 it('exports paths', function () {
@@ -104,6 +106,7 @@ it('exports paths', function () {
         ->crawl(false)
         ->paths(['/', '/about', '/feed/blog.atom', '/redirect'])
         ->export();
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
 });
 
 it('exports urls', function () {
@@ -111,6 +114,7 @@ it('exports urls', function () {
         ->crawl(false)
         ->urls([url('/'), url('/about'), url('/feed/blog.atom'), url('/redirect')])
         ->export();
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
 });
 
 it('exports mixed', function () {
@@ -119,15 +123,30 @@ it('exports mixed', function () {
         ->paths('/')
         ->urls(url('/about'), url('/feed/blog.atom'), url('/redirect'))
         ->export();
+
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
 });
 
 it('exports included files', function () {
     app(Exporter::class)
-        ->includeFiles([__DIR__.'/stubs/public' => ''])
+        ->includeFiles([__DIR__ . '/stubs/public' => ''])
         ->export();
 
-    assertFileExists(__DIR__.'/dist/favicon.ico');
-    assertFileExists(__DIR__.'/dist/media/image.png');
+    assertFileExists(__DIR__ . '/dist/favicon.ico');
+    assertFileExists(__DIR__ . '/dist/media/image.png');
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
 
-    expect(file_exists(__DIR__.'/dist/index.php'))->toBeFalse();
+    expect(file_exists(__DIR__ . '/dist/index.php'))->toBeFalse();
+});
+
+it('exports incliuding sitemap option', function () {
+    app(Exporter::class)
+        ->includeFiles([__DIR__ . '/stubs/public' => ''])
+        ->export(true);
+
+    assertFileExists(__DIR__ . '/dist/favicon.ico');
+    assertFileExists(__DIR__ . '/dist/media/image.png');
+    assertFileExists(__DIR__ . '/dist/sitemap.xml');
+
+    expect(file_exists(__DIR__ . '/dist/index.php'))->toBeFalse();
 });


### PR DESCRIPTION
This PR introduces an optional feature to generate a sitemap.xml file during the export process.

What's added:
A new `sitemap` boolean `config` option in config/export.php (default: true).

A new CLI flag:

`--sitemap` to explicitly enable sitemap generation.

Integration with the export flow to write the sitemap to the destination disk.

README updated with full documentation on the new config and CLI flag.

**Why this matters:**
This enhancement improves the SEO capabilities of exported static sites by including a sitemap.xml while keeping the behavior fully customizable and unobtrusive for existing users.

- Implement sitemap generation during export process.
- Add configuration option for sitemap in export.php.
- Update ExportCommand to handle sitemap option.
- Enhance Observer to generate sitemap after crawling.
- Create SitemapGenerator class for XML generation.
- Update README.md with sitemap usage instructions.
- Modify tests to verify sitemap generation.