### PR TITLE
Fix cross-platform test compatibility

### DIFF
--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -55,7 +55,10 @@ function assertRedirectExists(): void
 function assertExportedFile(string $path, string $content): void
 {
     assertFileExists($path);
-    assertEquals($content, file_get_contents($path));
+    // Normalize line endings for cross-platform compatibility
+    $expectedContent = str_replace(["\r\n", "\r"], "\n", $content);
+    $actualContent = str_replace(["\r\n", "\r"], "\n", file_get_contents($path));
+    assertEquals($expectedContent, $actualContent);
 }
 
 function assertRequestsHasHeader(): void


### PR DESCRIPTION
## Problem
Tests were failing on Windows due to line ending differences between Windows (`\r\n`) and Unix (`\n`) systems.

## Solution
- Normalize line endings in `assertExportedFile` function before comparing content
- Ensures tests pass consistently across Windows, Mac, and Linux
- Fixes failing tests due to `\r\n` vs `\n` differences in redirect HTML content

## Changes
- Modified `assertExportedFile()` in `tests/ExportTest.php` to normalize line endings
- No functional changes to the export functionality itself
- All existing tests now pass on Windows environment

## Testing
- ✅ All tests pass on Windows 11
- ✅ Verified fix addresses the specific line ending issue
- ✅ No breaking changes to existing functionality

Fixes cross-platform compatibility issues when running tests.