### PR TITLE
Use spatie/crawler:^9.1 and allow streaming

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4, 8.5]
+        php: [8.4, 8.5]
         laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .phpunit.result.cache
 .phpunit.cache/
 tests/dist/
+/.idea

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ return [
 ];
 ```
 
+By default, the crawler will use streaming to reduce memory usage. This is especially useful for large sites. You can disable this with the `use_streaming` option. This option only makes sense when the `crawl` option is enabled.
+
+```php
+return [
+    'use_streaming' => true,
+];
+```
+
 #### Paths
 
 `paths` is an array of URL paths that will be exported to HTML. Use this to manually determine which pages should be exported.
@@ -116,6 +124,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(Exporter $exporter)
     {
         $exporter->crawl(false);
+        $exporter->useStreaming(true);
 
         $exporter->paths(['', 'about', 'contact', 'posts']);
         $exporter->paths(Post::all()->pluck('slug'));

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ return [
 ];
 ```
 
-By default, the crawler will use streaming to reduce memory usage. This is especially useful for large sites. You can disable this with the `use_streaming` option. This option only makes sense when the `crawl` option is enabled.
+By default, streaming is disabled. Enable the `use_streaming` option to reduce memory usage when crawling large sites. This option only makes sense when the `crawl` option is enabled.
 
 ```php
 return [

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ composer test
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+## Upgrading
+
+Please see [UPGRADING](UPGRADING.md) for more information on how to upgrade to a new version.
+
 ## Contributing
 
 Please see [CONTRIBUTING](https://github.com/spatie/.github/blob/main/CONTRIBUTING.md) for details.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,27 @@
+# Upgrading
+
+## From 1.x to 2.x
+
+### High impact changes
+
+#### PHP 8.4 requirement
+
+The minimum PHP version is now 8.4.
+
+### Low impact changes
+
+#### Bump to `spatie/crawler` ^9.1
+
+This version now uses `spatie/crawler` ^9.1, which implements response streaming.
+
+If you have a large site and want to reduce memory usage during the export, you can enable streaming in your `config/export.php`:
+
+```php
+'use_streaming' => true,
+```
+
+By default, streaming is disabled.
+
+#### Internal API changes
+
+The `LocalClient` signature has changed. It is now an invokable class used as a Guzzle handler. If you were extending or using `LocalClient` directly, please review the updated implementation.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,27 +1,23 @@
 # Upgrading
 
-## From 1.x to 2.x
+## From 1.3 to 1.4
 
-### High impact changes
-
-#### PHP 8.4 requirement
+### PHP 8.4 requirement
 
 The minimum PHP version is now 8.4.
 
-### Low impact changes
+### `spatie/crawler` ^9.1
 
-#### Bump to `spatie/crawler` ^9.1
+This version uses `spatie/crawler` ^9.1, which supports response streaming.
 
-This version now uses `spatie/crawler` ^9.1, which implements response streaming.
-
-If you have a large site and want to reduce memory usage during the export, you can enable streaming in your `config/export.php`:
+If you have a large site and want to reduce memory usage during the export, you can enable streaming in `config/export.php`:
 
 ```php
 'use_streaming' => true,
 ```
 
-By default, streaming is disabled.
+By default, streaming is disabled, so behaviour is unchanged for existing installations.
 
-#### Internal API changes
+### Internal API changes
 
 The `LocalClient` signature has changed. It is now an invokable class used as a Guzzle handler. If you were extending or using `LocalClient` directly, please review the updated implementation.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^11.0|^12.0|^13.0",
         "nyholm/psr7": "^1.8.1",
         "psr/http-message": "^2.0",
-        "spatie/crawler": "^8.1",
+        "spatie/crawler": "^9.1",
         "symfony/console": "^6.4.2|^7.0",
         "symfony/dom-crawler": "^6.0|^7.0",
         "symfony/http-foundation": "^6.4.2|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "guzzlehttp/guzzle": "^7.8.1",
         "illuminate/console": "^11.0|^12.0|^13.0",
         "illuminate/contracts": "^11.0|^12.0|^13.0",

--- a/config/export.php
+++ b/config/export.php
@@ -9,6 +9,13 @@ return [
     'crawl' => true,
 
     /*
+     * If true, the crawler will use streaming to reduce memory usage.
+     *
+     * This option only makes sense when the `crawl` option is enabled.
+     */
+    'use_streaming' => true,
+
+    /*
      * Add additional paths to be added to the export here. If you're using the
      * `crawl` option, you probably don't need to add anything here.
      *

--- a/config/export.php
+++ b/config/export.php
@@ -13,7 +13,7 @@ return [
      *
      * This option only makes sense when the `crawl` option is enabled.
      */
-    'use_streaming' => true,
+    'use_streaming' => false,
 
     /*
      * Add additional paths to be added to the export here. If you're using the

--- a/src/Crawler/LocalClient.php
+++ b/src/Crawler/LocalClient.php
@@ -11,7 +11,7 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
-class LocalClient extends Client
+class LocalClient
 {
     /** @var \Illuminate\Contracts\Http\Kernel */
     protected $kernel;
@@ -21,8 +21,6 @@ class LocalClient extends Client
 
     public function __construct()
     {
-        parent::__construct();
-
         $this->kernel = app(HttpKernel::class);
 
         $psr17Factory = new Psr17Factory;
@@ -30,7 +28,7 @@ class LocalClient extends Client
         $this->psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
     }
 
-    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    public function __invoke(RequestInterface $request, array $options = []): PromiseInterface
     {
         $localRequest = Request::create((string) $request->getUri());
 

--- a/src/Crawler/LocalClient.php
+++ b/src/Crawler/LocalClient.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Export\Crawler;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -3,9 +3,8 @@
 namespace Spatie\Export\Crawler;
 
 use GuzzleHttp\Exception\RequestException;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
-use RuntimeException;
+use Spatie\Crawler\CrawlProgress;
+use Spatie\Crawler\CrawlResponse;
 use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Spatie\Export\Destination;
 use Spatie\Export\Traits\NormalizedPath;
@@ -26,29 +25,34 @@ class Observer extends CrawlObserver
         $this->destination = $destination;
     }
 
-    public function crawled(UriInterface $url, ResponseInterface $response, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
+    public function crawled(string $url, CrawlResponse $response, CrawlProgress $progress): void
     {
-        if (! $this->isSuccesfullOrRedirect($response->getStatusCode())) {
+        if (! $response->isSuccessful() && ! $response->isRedirect()) {
+            $foundOnUrl = $response->foundOnUrl();
+
             if (! empty($foundOnUrl)) {
-                throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->getStatusCode()}]");
+                throw new \RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->status()}]");
             }
 
-            throw new RuntimeException("URL [{$url}] returned status code [{$response->getStatusCode()}]");
+            throw new \RuntimeException("URL [{$url}] returned status code [{$response->status()}]");
         }
 
         $this->destination->write(
-            $this->normalizePath($url->getPath()),
-            (string) $response->getBody()
+            $this->normalizePath(parse_url($url, PHP_URL_PATH) ?? '/'),
+            $response->body()
         );
     }
 
-    public function crawlFailed(UriInterface $url, RequestException $requestException, ?UriInterface $foundOnUrl = null, ?string $linkText = null): void
-    {
+    public function crawlFailed(
+        string $url,
+        RequestException $requestException,
+        CrawlProgress $progress,
+        ?string $foundOnUrl = null,
+        ?string $linkText = null,
+        ?\Spatie\Crawler\Enums\ResourceType $resourceType = null,
+        ?\Spatie\Crawler\TransferStatistics $transferStats = null,
+    ): void {
         throw $requestException;
     }
 
-    protected function isSuccesfullOrRedirect(int $statusCode): bool
-    {
-        return in_array($statusCode, [200, 301, 302]);
-    }
 }

--- a/src/Crawler/Observer.php
+++ b/src/Crawler/Observer.php
@@ -3,9 +3,12 @@
 namespace Spatie\Export\Crawler;
 
 use GuzzleHttp\Exception\RequestException;
+use RuntimeException;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Spatie\Crawler\CrawlProgress;
 use Spatie\Crawler\CrawlResponse;
-use Spatie\Crawler\CrawlObservers\CrawlObserver;
+use Spatie\Crawler\Enums\ResourceType;
+use Spatie\Crawler\TransferStatistics;
 use Spatie\Export\Destination;
 use Spatie\Export\Traits\NormalizedPath;
 
@@ -31,10 +34,10 @@ class Observer extends CrawlObserver
             $foundOnUrl = $response->foundOnUrl();
 
             if (! empty($foundOnUrl)) {
-                throw new \RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->status()}]");
+                throw new RuntimeException("URL [{$url}] found on [{$foundOnUrl}] returned status code [{$response->status()}]");
             }
 
-            throw new \RuntimeException("URL [{$url}] returned status code [{$response->status()}]");
+            throw new RuntimeException("URL [{$url}] returned status code [{$response->status()}]");
         }
 
         $this->destination->write(
@@ -49,10 +52,9 @@ class Observer extends CrawlObserver
         CrawlProgress $progress,
         ?string $foundOnUrl = null,
         ?string $linkText = null,
-        ?\Spatie\Crawler\Enums\ResourceType $resourceType = null,
-        ?\Spatie\Crawler\TransferStatistics $transferStats = null,
+        ?ResourceType $resourceType = null,
+        ?TransferStatistics $transferStats = null,
     ): void {
         throw $requestException;
     }
-
 }

--- a/src/ExportServiceProvider.php
+++ b/src/ExportServiceProvider.php
@@ -36,7 +36,7 @@ class ExportServiceProvider extends ServiceProvider
         $this->app->make(Exporter::class)
             ->cleanBeforeExport(config('export.clean_before_export', false))
             ->crawl(config('export.crawl', false))
-            ->useStreaming(config('export.use_streaming', true))
+            ->useStreaming(config('export.use_streaming', false))
             ->paths(config('export.paths', []))
             ->includeFiles(config('export.include_files', []))
             ->excludeFilePatterns(config('export.exclude_file_patterns', []));

--- a/src/ExportServiceProvider.php
+++ b/src/ExportServiceProvider.php
@@ -36,6 +36,7 @@ class ExportServiceProvider extends ServiceProvider
         $this->app->make(Exporter::class)
             ->cleanBeforeExport(config('export.clean_before_export', false))
             ->crawl(config('export.crawl', false))
+            ->useStreaming(config('export.use_streaming', true))
             ->paths(config('export.paths', []))
             ->includeFiles(config('export.include_files', []))
             ->excludeFilePatterns(config('export.exclude_file_patterns', []));

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -24,6 +24,9 @@ class Exporter
     /** @var bool */
     protected $crawl = false;
 
+    /** @var bool */
+    protected $useStreaming = true;
+
     /** @var string[] */
     protected $paths = [];
 
@@ -49,6 +52,13 @@ class Exporter
     public function crawl(bool $crawl): self
     {
         $this->crawl = $crawl;
+
+        return $this;
+    }
+
+    public function useStreaming(bool $useStreaming): self
+    {
+        $this->useStreaming = $useStreaming;
 
         return $this;
     }
@@ -97,7 +107,7 @@ class Exporter
 
         if ($this->crawl) {
             $this->dispatcher->dispatchNow(
-                new CrawlSite
+                new CrawlSite($this->useStreaming)
             );
         }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -25,7 +25,7 @@ class Exporter
     protected $crawl = false;
 
     /** @var bool */
-    protected $useStreaming = true;
+    protected $useStreaming = false;
 
     /** @var string[] */
     protected $paths = [];

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -15,7 +15,7 @@ class CrawlSite
     /** @var bool */
     protected $useStreaming;
 
-    public function __construct(bool $useStreaming = true)
+    public function __construct(bool $useStreaming = false)
     {
         $this->useStreaming = $useStreaming;
     }

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -20,6 +20,11 @@ class CrawlSite
         $this->useStreaming = $useStreaming;
     }
 
+    public function useStreaming(): bool
+    {
+        return $this->useStreaming;
+    }
+
     public function handle(UrlGenerator $urlGenerator, Destination $destination): void
     {
         $entry = $urlGenerator->to('/');

--- a/src/Jobs/CrawlSite.php
+++ b/src/Jobs/CrawlSite.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Export\Jobs;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Spatie\Crawler\Crawler;
 use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
@@ -11,13 +12,30 @@ use Spatie\Export\Destination;
 
 class CrawlSite
 {
+    /** @var bool */
+    protected $useStreaming;
+
+    public function __construct(bool $useStreaming = true)
+    {
+        $this->useStreaming = $useStreaming;
+    }
+
     public function handle(UrlGenerator $urlGenerator, Destination $destination): void
     {
         $entry = $urlGenerator->to('/');
 
-        (new Crawler(new LocalClient))
-            ->setCrawlObserver(new Observer($entry, $destination))
-            ->setCrawlProfile(new CrawlInternalUrls($entry))
-            ->startCrawling($entry);
+        $crawler = Crawler::create($entry, [
+            RequestOptions::ALLOW_REDIRECTS => false,
+            'handler' => new LocalClient(),
+        ]);
+
+        if ($this->useStreaming) {
+            $crawler->stream();
+        }
+
+        $crawler
+            ->addObserver(new Observer($entry, $destination))
+            ->crawlProfile(new CrawlInternalUrls($entry))
+            ->start();
     }
 }

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Testing\Fakes\BusFake;
 use Spatie\Export\Exporter;
+use Spatie\Export\Jobs\CrawlSite;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFileExists;
@@ -91,6 +94,11 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (Bus::getFacadeRoot() instanceof BusFake) {
+        // Disable file-based assertions when bus is faked
+        return;
+    }
+
     assertHomeExists();
     assertAboutExists();
     assertFeedBlogAtomExists();
@@ -100,14 +108,29 @@ afterEach(function () {
 
 it('crawls and exports routes', function () {
     app(Exporter::class)
+        ->crawl(true)
+        ->export();
+});
+
+it('crawls and exports routes while using streaming', function () {
+   app(Exporter::class)
+        ->crawl(true)
         ->useStreaming(true)
         ->export();
 });
 
-it('can disable streaming', function () {
+it('can enable streaming', function () {
+    $this->app->forgetInstance(Exporter::class);
+    Bus::fake();
+
     app(Exporter::class)
-        ->useStreaming(false)
+        ->crawl(true)
+        ->useStreaming(true)
         ->export();
+
+    Bus::assertDispatched(CrawlSite::class, function (CrawlSite $job) {
+        return $job->useStreaming() === true;
+    });
 });
 
 it('exports paths', function () {

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -113,7 +113,7 @@ it('crawls and exports routes', function () {
 });
 
 it('crawls and exports routes while using streaming', function () {
-   app(Exporter::class)
+    app(Exporter::class)
         ->crawl(true)
         ->useStreaming(true)
         ->export();

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -99,7 +99,9 @@ afterEach(function () {
 });
 
 it('crawls and exports routes', function () {
-    app(Exporter::class)->export();
+    app(Exporter::class)
+        ->useStreaming(true)
+        ->export();
 });
 
 it('can disable streaming', function () {

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -102,6 +102,12 @@ it('crawls and exports routes', function () {
     app(Exporter::class)->export();
 });
 
+it('can disable streaming', function () {
+    app(Exporter::class)
+        ->useStreaming(false)
+        ->export();
+});
+
 it('exports paths', function () {
     app(Exporter::class)
         ->crawl(false)


### PR DESCRIPTION
Hi Spatie team,

I regularly use your packages—thanks a lot for the work you put into maintaining them.

This PR adds support for spatie/crawler ^9.1 and introduces the use of streaming responses available in that version.

There’s definitely room for improvement, and I’m not entirely convinced that enabling streaming by default when crawling is the right choice. I’d really appreciate your thoughts on this.